### PR TITLE
Fix: TimeEntry.Pid should be nullable

### DIFF
--- a/Toggl.Api/Models/TimeEntry.cs
+++ b/Toggl.Api/Models/TimeEntry.cs
@@ -56,7 +56,7 @@ public class TimeEntry : IdentifiedItem
 	/// Project ID, legacy field
 	/// </summary>
 	[JsonPropertyName("pid")]
-	public required long Pid { get; set; }
+	public long? Pid { get; set; }
 
 	/// <summary>
 	/// Is Project Active


### PR DESCRIPTION
Fix in TimeEntry.Pid, change from `required long` to `long?`