### PR TITLE
Make Permissions property optional on ProjectTask

### DIFF
--- a/Toggl.Api/Models/ProjectTask.cs
+++ b/Toggl.Api/Models/ProjectTask.cs
@@ -30,7 +30,7 @@ public class ProjectTask : NamedIdentifiedItem
 	/// Permissions
 	/// </summary>
 	[JsonPropertyName("permissions")]
-	public required string Permissions { get; set; }
+	public string Permissions { get; set; }
 
 	/// <summary>
 	/// Project id


### PR DESCRIPTION
Make Permissions property optional on ProjectTask to match data returned from Toggl API